### PR TITLE
Specify old-style percent delimiters

### DIFF
--- a/rubocop/default.yml
+++ b/rubocop/default.yml
@@ -136,3 +136,12 @@ Style/TrailingCommaInArguments:
 # This can be worse for diffs if we know it's variable
 Style/WordArray:
   Enabled: false
+
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    default: '()'
+    '%i': '()'
+    '%I': '()'
+    '%r': '{}'
+    '%w': '()'
+    '%W': '()'


### PR DESCRIPTION
As of early 2017, rubocop defaults have changed for array percent
literal delimiters from parentheses to square brackets (bringing it in
line with the Ruby Style Guide - see below). Our style guide
specifies parens, so to maintain this we must override the styles in
Rubocop.