### PR TITLE
Propose rule disabling

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -35,6 +35,9 @@ module.exports = {
 
     // disabled
     "valid-jsdoc": 0,
-    "require-jsdoc": 0
+    "require-jsdoc": 0,
+    "import/extensions": 0,
+    "import/no-unresolved": 0,
+    "import/no-extraneous-dependencies": 0
   }
 };


### PR DESCRIPTION
On Commercial, we have a lot of imports that following this format: 
```js
import UI from '@commercial/constants/ui';
```
and `eslint` flags these lines as: 
1. `Unable to resolve path to module '@commercial/constants/ui'`
2. `'@commercial/constants' should be listed in the project's dependencies.`
3. `Missing file extension for "@commercial/constants/ui`

I propose that we disable these three rules as we don't use file extensions in our imports and because the `@commercial/blah` pattern is very common and used everywhere in the code base. 

Suggestions, feedback and alternatives welcome!