### PR TITLE
prevent == 0 from setting off Rubocop

### DIFF
--- a/rubocop/default.yml
+++ b/rubocop/default.yml
@@ -121,6 +121,11 @@ Style/DoubleNegation:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+# Better to use `== 0` than `.zero?` at least for some cases
+Style/NumericPredicate:
+  Enabled: false
+
+
 # While we prefer single quotes for require and gem statements, it's
 # easier to read code with a more consistent style
 Style/StringLiterals:


### PR DESCRIPTION
I've run into [cases](https://github.com/coverhound/commercial/pull/975/files#diff-94f3509f1625fa38c1d3ad3a2e556d49R52) where I'm checking whether a thing that could be either a `Numeric` or a `String` is equal to `0`. Rubocop wants me to favor `.zero?` over `== 0`. However, `.zero?` is not a method on `String`. Use of `.zero?` should be optional, not required.