### PR TITLE
Disable Performance/Casecmp for Rubocop

### DIFF
--- a/rubocop/default.yml
+++ b/rubocop/default.yml
@@ -145,3 +145,9 @@ Style/TrailingCommaInArguments:
 Style/WordArray:
   Enabled: false
 
+# ========================================
+# PERFORMANCE
+# ========================================
+# This is less readable for a 20% performance boost
+Performance/Casecmp:
+  Enabled: false


### PR DESCRIPTION
Casecmp, while more performant by ~20%, is less readable.