### PR TITLE
Addresses depracated cop issue

### DIFF
--- a/rubocop/default.yml
+++ b/rubocop/default.yml
@@ -126,7 +126,10 @@ Style/StringLiterals:
 #     :three,
 #   ]
 #
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 # See ^


### PR DESCRIPTION
    `[Linter] Error running RuboCop Error: Error: The
    "Style/TrailingCommaInLiteral" cop no longer exists. Please use
    "Style/TrailingCommaInArrayLiteral" and/or
    "Style/TrailingCommaInHashLiteral" instead.
    (obsolete configuration found in
    /root/path/to/rubocop-config-coverhound-1.1.0/default.yml, please update it)`