### PR TITLE
Update Ruby style guide to use rubocop v0.56

### DIFF
--- a/rubocop/Gemfile.lock
+++ b/rubocop/Gemfile.lock
@@ -2,27 +2,27 @@ PATH
   remote: .
   specs:
     rubocop-config-coverhound (1.1.0)
-      rubocop (~> 0.49)
+      rubocop (~> 0.56)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.3.0)
-    parallel (1.11.2)
-    parser (2.4.0.0)
-      ast (~> 2.2)
+    ast (2.4.0)
+    parallel (1.12.1)
+    parser (2.5.1.0)
+      ast (~> 2.4.0)
     powerpack (0.1.1)
-    rainbow (2.1.0)
+    rainbow (3.0.0)
     rake (10.5.0)
-    rubocop (0.49.1)
+    rubocop (0.56.0)
       parallel (~> 1.10)
-      parser (>= 2.3.3.1, < 3.0)
+      parser (>= 2.5)
       powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.8.1)
-    unicode-display_width (1.1.1)
+    ruby-progressbar (1.9.0)
+    unicode-display_width (1.3.2)
 
 PLATFORMS
   ruby
@@ -33,4 +33,4 @@ DEPENDENCIES
   rubocop-config-coverhound!
 
 BUNDLED WITH
-   1.15.1
+   1.16.1

--- a/rubocop/rubocop-config-coverhound.gemspec
+++ b/rubocop/rubocop-config-coverhound.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/coverhound/coverhound-style"
   spec.files         = Dir["README.md", "default.yml"]
 
-  spec.add_dependency "rubocop", "~> 0.49"
+  spec.add_dependency "rubocop", "~> 0.56"
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
## Summary
> Updates `rubocop` to use version `~> 0.56` since `0.49.1` is almost a year old to the day.

The motivation for this was twofold:
1. Use the latest version of the package which brings lots of rule fixes/bug fixes and new goodies.
2. Upgrade `rubocop`'s dependencies. Specifically, `rubocop` < `0.50` depends on `rainbow` < `3.0.0`, which was preventing upgrading `react_on_rails` to any version above `11.0.3`.

## Changelog of Features
[Here](https://github.com/bbatsov/rubocop/releases). 