### PR TITLE
Upgrade gem version

### DIFF
--- a/rubocop/README.md
+++ b/rubocop/README.md
@@ -43,3 +43,9 @@ $ bundle exec rubocop
 You do not need to include `rubocop` directly in your application's dependences.
 `rubocop-config-coverhound` will include a specific version of `rubocop` that is shared across
 all projects.
+
+## Versioning
+
+We are pegging our major versions to Rubocop minor versions. Rubop patch
+versions would indicate a minor version bump for us. A patch for us would
+indicate a change only for us, not in our upstream dependencies.

--- a/rubocop/rubocop-config-coverhound.gemspec
+++ b/rubocop/rubocop-config-coverhound.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-config-coverhound"
-  spec.version       = "1.3.0"
+  spec.version       = "2.0"
   spec.authors       = ["Bernardo Farah"]
   spec.email         = ["ber@bernardo.me"]
   spec.licenses      = ["MIT"]


### PR DESCRIPTION
We are pegging our major versions to Rubocop minor versions. Rubop patch
versions would indicate a minor version bump for us. A patch for us
would indicate a change only for us, not in our upstream dependencies.